### PR TITLE
Add enabled paymaster state and validation

### DIFF
--- a/src/PermissionManager.sol
+++ b/src/PermissionManager.sol
@@ -50,6 +50,9 @@ contract PermissionManager is IERC1271, Ownable, Pausable {
     /// @notice Permission contract not enabled.
     error DisabledPermissionContract();
 
+    /// @notice Paymaster contract not enabled.
+    error DisabledPaymaster();
+
     /// @notice Permission has expired.
     error ExpiredPermission();
 
@@ -61,6 +64,12 @@ contract PermissionManager is IERC1271, Ownable, Pausable {
     /// @param permissionContract The contract resposible for checking permission logic.
     /// @param enabled The new setting allowing/preventing use.
     event PermissionContractUpdated(address indexed permissionContract, bool enabled);
+
+    /// @notice Paymaster setting updated.
+    ///
+    /// @param paymaster ERC-4337 paymaster contract.
+    /// @param enabled The new setting allowing/preventing use.
+    event PaymasterUpdated(address indexed paymaster, bool enabled);
 
     /// @notice Paymaster gas spend setting updated.
     ///
@@ -96,6 +105,11 @@ contract PermissionManager is IERC1271, Ownable, Pausable {
     ///
     /// @dev Storage not keyable by account, can only be accessed in execution phase.
     mapping(address permissionContract => bool enabled) public isPermissionContractEnabled;
+
+    /// @notice Track if paymasters are enabled.
+    ///
+    /// @dev Storage not keyable by account, can only be accessed in execution phase.
+    mapping(address paymaster => bool enabled) public isPaymasterEnabled;
 
     /// @notice Track if a permission contract should account for gas spent by paymaster.
     ///
@@ -173,6 +187,7 @@ contract PermissionManager is IERC1271, Ownable, Pausable {
             PermissionManager.checkBeforeCalls.selector,
             permission.expiry,
             permission.permissionContract,
+            address(bytes20(userOp.paymasterAndData)),
             userOpHash,
             userOpCosignature
         );
@@ -201,6 +216,7 @@ contract PermissionManager is IERC1271, Ownable, Pausable {
     ///      * Manager paused state
     ///      * Expiry TIMESTAMP opcode
     ///      * Enabled permission contract state
+    ///      * Enabled paymaster state
     ///      * Cosigner and pendingCosigner state
     ///
     /// @param expiry Unix timestamp this permission is valid until.
@@ -210,6 +226,7 @@ contract PermissionManager is IERC1271, Ownable, Pausable {
     function checkBeforeCalls(
         uint256 expiry,
         address permissionContract,
+        address paymaster,
         bytes32 userOpHash,
         bytes calldata userOpCosignature
     ) external view whenNotPaused {
@@ -218,6 +235,9 @@ contract PermissionManager is IERC1271, Ownable, Pausable {
 
         // check permission contract enabled
         if (!isPermissionContractEnabled[permissionContract]) revert DisabledPermissionContract();
+
+        // check paymaster enabled
+        if (!isPaymasterEnabled[paymaster]) revert DisabledPaymaster();
 
         // check userOpCosignature from cosigner or pendingCosigner
         if (
@@ -268,6 +288,15 @@ contract PermissionManager is IERC1271, Ownable, Pausable {
     function setPermissionContractEnabled(address permissionContract, bool enabled) external onlyOwner {
         isPermissionContractEnabled[permissionContract] = enabled;
         emit PermissionContractUpdated(permissionContract, enabled);
+    }
+
+    /// @notice Set paymaster enabled status.
+    ///
+    /// @param paymaster ERC-4337 paymaster contract.
+    /// @param enabled True if the contract is enabled.
+    function setPaymasterEnabled(address paymaster, bool enabled) external onlyOwner {
+        isPaymasterEnabled[paymaster] = enabled;
+        emit PaymasterUpdated(paymaster, enabled);
     }
 
     /// @notice Set paymaster should add gas spend or not.


### PR DESCRIPTION
Some paymaster implementations have the ability to spend user non-native assets (e.g. ERC20 Paymaster). Unknown implementations may have other important consequences that will be hard for us to block, so we require all paymaster implementations to be registered on an allowlist to be compatible with Smart Wallet Permissions.

We place this allowlist onchain instead of offchain enforced via cosigner to follow the principle that cosigner is to prevent abuse, not for basic security we can handle onchain. Coinbase will need to publicize and maintain a path for third-party developers to request adding their paymaster to this allowlist and for us to internally audit these requests and publish them onchain.