### PR TITLE
[DRAFT] Add ERC20 Rolling Allowances

### DIFF
--- a/docs/diagrams/onchain/permissionedCalls.md
+++ b/docs/diagrams/onchain/permissionedCalls.md
@@ -8,6 +8,7 @@ sequenceDiagram
     participant M as Permission Manager
     participant P as Permission Contract
     participant C as External Contract
+    participant ERC20 as ERC20
 
     E->>A: validateUserOp
     Note left of E: Validation phase
@@ -28,6 +29,10 @@ sequenceDiagram
     opt
         A->>P: approveRollingAllowances
         Note over A,P: one-time initialization of rolling allowances
+    end
+    loop
+        A->>ERC20: approve
+        Note over ERC20,A: send intended calldata wrapped with special selector
     end
     loop
         A->>C: permissionedCall

--- a/docs/diagrams/onchain/permissionedCalls.md
+++ b/docs/diagrams/onchain/permissionedCalls.md
@@ -25,10 +25,14 @@ sequenceDiagram
     Note left of E: Execution phase
     A->>M: checkBeforeCalls
     Note over M: Execution phase checks: ‎ ‎ ‎ ‎ ‎ ‎ ‎ ‎ ‎ ‎  <br/> 1. manager not paused ‎ ‎ ‎ ‎ ‎ ‎ ‎ ‎ ‎ ‎ ‎ ‎ <br/> 2. permission contract enabled <br/> 3. cosigner signed userOp ‎ ‎ ‎ ‎ ‎ ‎ ‎ ‎ <br/> 4. permission not expired ‎ ‎ ‎ ‎ ‎ ‎ ‎ ‎
+    opt
+        A->>P: approveRollingAllowances
+        Note over A,P: one-time initialization of rolling allowances
+    end
     loop
         A->>C: permissionedCall
         Note over C,A: send intended calldata wrapped with special selector
     end
-    A->>P: assertSpend
-    Note over A,P: assert spend within rolling limit
+    A->>P: assertSpends
+    Note over A,P: assert spends within rolling allowances
 ```

--- a/docs/erc7715.md
+++ b/docs/erc7715.md
@@ -26,10 +26,13 @@ type AccountSigner = {
 ### Permission types
 
 ```tsx
-type NativeTokenRollingSpendLimitPermission = {
-  type: "native-token-rolling-spend-limit";
+type RollingAllowancePermission = {
+  type: "rolling-allowance";
   data: {
-    spendLimit: `0x${string}`; // hex for uint256
+    rollingAllowances: {
+      token: `0x${string}`; // ERC20 contract address or address(0) for native token
+      value: `0x${string}`; // hex for uint256
+    }[];
     rollingPeriod: number; // unix seconds
     allowedContract: `0x${string}`; // address
   };

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -6,7 +6,7 @@ import {Strings} from "openzeppelin-contracts/contracts/utils/Strings.sol";
 
 import {PermissionManager} from "../src/PermissionManager.sol";
 import {Click} from "../src/examples/Click.sol";
-import {NativeTokenRollingSpendLimitPermission} from
+import {RollingAllowancePermission} from
     "../src/permissions/NativeTokenRollingSpendLimit/NativeTokenRollingSpendLimitPermission.sol";
 
 // forge script Deploy --account dev --rpc-url $BASE_SEPOLIA_RPC --verify --verifier-url $SEPOLIA_BASESCAN_API

--- a/src/permissions/NativeTokenRollingSpendLimit/NativeTokenRollingSpendLimitPermission.sol
+++ b/src/permissions/NativeTokenRollingSpendLimit/NativeTokenRollingSpendLimitPermission.sol
@@ -59,9 +59,6 @@ contract RollingAllowancePermission is IPermissionContract {
     /// @notice Rolling period is zero.
     error ZeroRollingPeriod();
 
-    /// @notice Rolling period is zero.
-    error RollingPeriodImmutable();
-
     /// @notice Non-zero allowance value leftover from calls.
     error LeftoverAllowance();
 
@@ -210,9 +207,6 @@ contract RollingAllowancePermission is IPermissionContract {
     function approveRollingAllowances(bytes32 permissionHash, RollingAllowance[] calldata rollingAllowances, uint256 rollingPeriod) external {
         // check rolling period is non-zero
         if (rollingPeriod == 0) revert ZeroRollingPeriod();
-
-        // check rolling period not set yet
-        if (_rollingPeriods[msg.sender][permissionHash] > 0) revert RollingPeriodImmutable();
         
         _rollingPeriods[msg.sender][permissionHash] = rollingPeriod;
 
@@ -245,7 +239,7 @@ contract RollingAllowancePermission is IPermissionContract {
         address paymaster
     ) external {
         uint256 rollingPeriod = _rollingPeriods[msg.sender][permissionHash];
-        if (rollingPeriod == 0) revert(); // not set
+        if (rollingPeriod == 0) revert ZeroRollingPeriod();
 
         uint256 totalNativeSpend = callsSpend;
         // add gas cost to total native spend if beared by the user

--- a/src/permissions/NativeTokenRollingSpendLimit/NativeTokenRollingSpendLimitPermission.sol
+++ b/src/permissions/NativeTokenRollingSpendLimit/NativeTokenRollingSpendLimitPermission.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.23;
 
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+
 import {PermissionManager} from "../../PermissionManager.sol";
 import {ICoinbaseSmartWallet} from "../../utils/ICoinbaseSmartWallet.sol";
 import {Bytes} from "../../utils/Bytes.sol";
@@ -9,15 +11,15 @@ import {UserOperation, UserOperationUtils} from "../../utils/UserOperationUtils.
 import {IPermissionContract} from "../IPermissionContract.sol";
 import {IPermissionCallable} from "../PermissionCallable/IPermissionCallable.sol";
 
-/// @title NativeTokenRollingSpendLimitPermission
+/// @title RollingAllowancePermission
 ///
-/// @notice Supports spending native token with rolling limits.
+/// @notice Supports spending native token and ERC20s with rolling limits.
 /// @notice Only allow calls to a single allowed contract using IPermissionCallable.permissionedCall selector.
 ///
 /// @dev Called by PermissionManager at end of its validation flow.
 ///
 /// @author Coinbase (https://github.com/coinbase/smart-wallet-permissions)
-contract NativeTokenRollingSpendLimitPermission is IPermissionContract {
+contract RollingAllowancePermission is IPermissionContract {
     /// @notice Spend of native token at a specific time.
     struct Spend {
         /// @dev Unix timestamp of the spend.
@@ -26,11 +28,30 @@ contract NativeTokenRollingSpendLimitPermission is IPermissionContract {
         uint208 value;
     }
 
+    /// @notice Allowance for Native or ERC20 token over a rolling period.
+    struct RollingAllowance {
+        /// @dev ERC20 contract address or address(0) for native token.
+        address token;
+        /// @dev Allowance value that can be spent over a rolling period.
+        uint256 value;
+    }
+
+    /// @notice Approval call made on a token for an allowed contract to spend value.
+    struct ERC20Approval {
+        /// @dev ERC20 contract address approval is granted on.
+        address erc20;
+        /// @dev Spend value for the approval.
+        uint256 value;
+    }
+
     /// @notice MagicSpend withdraw asset is not native token.
     error InvalidWithdrawAsset();
 
     /// @notice Call to assertSpend not made on self or with invalid data.
     error InvalidAssertSpendCall();
+    
+    /// @notice Spend assertation call not made in last call.
+    error MustAssertERC20SpendsSecondLastCall();
 
     /// @notice Spend value exceeds max size of uint208
     error SpendValueOverflow();
@@ -39,10 +60,19 @@ contract NativeTokenRollingSpendLimitPermission is IPermissionContract {
     error ExceededSpendingLimit();
 
     /// @notice Register native token spend for a permission
-    event SpendRegistered(address indexed account, bytes32 indexed permissionHash, uint256 value);
+    event SpendRegistered(address indexed account, bytes32 indexed permissionHash, address token, uint256 value);
+
+    /// @notice Approve a rolling allowance on native token or ERC20.
+    event RollingAllowanceApproved(address indexed account, bytes32 indexed permissionHash, address indexed token, uint256 rollingAllowance, uint256 rollingPeriod);
 
     /// @notice All native token spends per account per permission.
-    mapping(address account => mapping(bytes32 permissionHash => Spend[] spends)) internal _spends;
+    mapping(address account => mapping(bytes32 permissionHash => mapping(address token => Spend[] spends))) internal _spends;
+
+    /// @notice Rolling period for a permission.
+    mapping(address account => mapping(bytes32 permissionHash => uint256 rollingPeriod)) internal _rollingPeriods;
+
+    /// @notice Rolling token allowances for a permission.
+    mapping(address account => mapping(bytes32 permissionHash => mapping(address token => uint256 allowance))) internal _rollingAllowances;
 
     /// @notice PermissionManager this permission contract trusts for paymaster gas spend data.
     PermissionManager public immutable permissionManager;
@@ -66,19 +96,21 @@ contract NativeTokenRollingSpendLimitPermission is IPermissionContract {
         view
     {
         // parse permission fields
-        (uint256 spendLimit, uint256 rollingPeriod, address allowedContract) =
-            abi.decode(permissionFields, (uint256, uint256, address));
+        (RollingAllowance[] memory rollingAllowances, uint256 rollingPeriod, address allowedContract) =
+            abi.decode(permissionFields, (RollingAllowance[], uint256, address));
 
         // parse user operation call data as `executeBatch` arguments (call array)
         ICoinbaseSmartWallet.Call[] memory calls = abi.decode(userOp.callData[4:], (ICoinbaseSmartWallet.Call[]));
 
         // initialize loop accumulators
-        uint256 callsSpend = 0;
+        uint256 callsNativeSpend = 0;
+        ERC20Approval[] memory approvals = new ERC20Approval[](rollingAllowances.length);
+        uint256 approvalCount = 0;
 
         // loop over calls to validate native token spend and allowed contracts
         // start index at 1 to ignore first call, enforced by PermissionManager as validation call on itself
-        // end index at calls.length - 2 to ignore assertSpend call, enforced after loop as validation call on self
-        for (uint256 i = 1; i < calls.length - 1; i++) {
+        // end index at calls.length - 3 to ignore assertERC20Spends and assertSpends calls, enforced after loop as validation call on self
+        for (uint256 i = 1; i < calls.length - 2; i++) {
             ICoinbaseSmartWallet.Call memory call = calls[i];
             bytes4 selector = bytes4(call.data);
 
@@ -96,29 +128,83 @@ contract NativeTokenRollingSpendLimitPermission is IPermissionContract {
                 // do not need to accrue callsSpend because withdrawn value will be spent in other calls
             } else if (selector == IMagicSpend.withdrawGasExcess.selector) {
                 // ok
+            } else if (selector == IERC20.approve.selector) {
+                (address spender, uint256 value) = abi.decode(call.data, (address, uint256));
+                
+                // check spender is allowed contract
+                if (spender != allowedContract) revert();
+
+                // check nonzero approval
+                if (value == 0) revert();
+                
+                // add approval to array
+                approvals[approvalCount] = ERC20Approval(call.target, value);
+
+                // increment approval count
+                ++approvalCount;
+            } else if (selector == RollingAllowancePermission.approveRollingAllowances.selector) {
+                // prepare expected call data for approveRollingAllowances
+                bytes memory approveRollingSpendData = abi.encodeWithSelector(
+                    RollingAllowancePermission.approveRollingAllowances.selector,
+                    permissionHash,
+                    rollingAllowances,
+                    rollingPeriod
+                );
+
+                if (!_isExpectedSelfCall(call, approveRollingSpendData)) revert();
             } else {
                 revert UserOperationUtils.SelectorNotAllowed();
             }
 
             // accumulate spend value
-            callsSpend += call.value;
+            callsNativeSpend += call.value;
         }
 
-        // prepare expected call data for assertSpend
-        bytes memory assertSpendData = abi.encodeWithSelector(
-            NativeTokenRollingSpendLimitPermission.assertSpend.selector,
+
+        // copy approvals into shorter usedApprovals array
+        ERC20Approval[] memory usedApprovals = new ERC20Approval[](approvalCount);
+        for (uint256 i = 0; i < approvalCount; i++) {
+            usedApprovals[i] = approvals[i];
+        }
+
+        // prepare expected call data for assertSpends
+        bytes memory assertSpendsData = abi.encodeWithSelector(
+            RollingAllowancePermission.assertSpends.selector,
             permissionHash,
-            spendLimit,
-            rollingPeriod,
-            callsSpend,
+            usedApprovals,
+            callsNativeSpend,
             // gasSpend is prefund required by entrypoint (ignores refund for unused gas)
             UserOperationUtils.getRequiredPrefund(userOp),
+            allowedContract,
             // paymaster data is empty or first 20 bytes are contract address
             userOp.paymasterAndData.length == 0 ? address(0) : address(bytes20(userOp.paymasterAndData[:20]))
         );
 
-        // check that last call is assertSpend
-        if (!_isExpectedSelfCall(calls[calls.length - 1], assertSpendData)) revert InvalidAssertSpendCall();
+        // check that last call is assertSpends
+        if (!_isExpectedSelfCall(calls[calls.length - 1], assertSpendsData)) revert InvalidAssertSpendCall();
+    }
+
+    /// @notice Approve rolling token allowances.
+    ///
+    /// @dev Accounts can call this even if without approving the permission. 
+    /// @dev Wallet interfaces recommended to block normal transactions that call this function.
+    /// @dev A rolling allowance must be approved here before it can be spent in assertSpends.
+    ///
+    /// @param permissionHash Hash of the permission.
+    /// @param rollingAllowances Tokens and allowances to apply on the rolling period.
+    /// @param rollingPeriod Time in seconds to look back from now for current spend period.
+    function approveRollingAllowances(bytes32 permissionHash, RollingAllowance[] calldata rollingAllowances, uint256 rollingPeriod) external {
+        if (rollingPeriod == 0) revert(); // >0
+        if (_rollingPeriods[msg.sender][permissionHash] > 0) revert(); // already set
+        
+        _rollingPeriods[msg.sender][permissionHash] = rollingPeriod;
+
+        uint256 rollingAllowancesLen = rollingAllowances.length;
+        for (uint256 i = 0; i < rollingAllowancesLen; i++) {
+            RollingAllowance memory rollingAllowance = rollingAllowances[i];
+            _rollingAllowances[msg.sender][permissionHash][rollingAllowance.token] = rollingAllowance.value;
+            emit RollingAllowanceApproved(msg.sender, permissionHash, rollingAllowance.token, rollingAllowance.value, rollingPeriod);
+        }
     }
 
     /// @notice Register a spend of native token for a given permission.
@@ -127,48 +213,61 @@ contract NativeTokenRollingSpendLimitPermission is IPermissionContract {
     /// @dev State read on Manager for adding paymaster gas to total spend must happen in execution phase.
     ///
     /// @param permissionHash Hash of the permission.
-    /// @param spendLimit Value of native token that cannot be exceeded over the rolling period.
-    /// @param rollingPeriod Seconds duration for the rolling period.
+    /// @param erc20Approvals ERC20 approvals granted and used in earlier calls.
     /// @param callsSpend Value of native token spent in calls.
     /// @param gasSpend Value of native token spent by gas.
+    /// @param approvalSpender External contract called by account to spend approvals.
     /// @param paymaster Paymaster used by user operation.
-    function assertSpend(
+    function assertSpends(
         bytes32 permissionHash,
-        uint256 spendLimit,
-        uint256 rollingPeriod,
+        ERC20Approval[] calldata erc20Approvals,
         uint256 callsSpend,
         uint256 gasSpend,
+        address approvalSpender,
         address paymaster
     ) external {
-        uint256 totalSpend = callsSpend;
+        uint256 rollingPeriod = _rollingPeriods[msg.sender][permissionHash];
+        if (rollingPeriod == 0) revert(); // not set
 
-        // add gas cost if beared by the user
+        uint256 totalNativeSpend = callsSpend;
+        // add gas cost to total native spend if beared by the user
         if (paymaster == address(0) || permissionManager.shouldAddPaymasterGasToTotalSpend(paymaster)) {
-            totalSpend += gasSpend;
+            totalNativeSpend += gasSpend;
             // recall MagicSpend enforces withdraw to be native token when used as a paymaster
         }
 
         // assert native token spend
-        _assertSpend(permissionHash, totalSpend, spendLimit, rollingPeriod);
+        _assertSpend(permissionHash, address(0), totalNativeSpend, rollingPeriod);
+
+        uint256 erc20ApprovalsLen = erc20Approvals.length;
+        for (uint256 i = 0; i < erc20ApprovalsLen; i++) {
+            ERC20Approval memory approval = erc20Approvals[i];
+
+            // require current allowance is now zero to verify allowance was spent in full
+            if (IERC20(approval.erc20).allowance(msg.sender, approvalSpender) > 0) revert();
+
+            // assert erc20 spend
+            _assertSpend(permissionHash, approval.erc20, approval.value, rollingPeriod);
+        }
     }
 
     /// @notice Calculate rolling spend for the period.
     ///
-    /// @param account The account tied to the permission.
-    /// @param permissionHash Hash of the permission.
+    /// @param account The account to localize to.
+    /// @param permissionHash The unique permission to localize to.
     /// @param rollingPeriod Time in seconds to look back from now for current spend period.
     ///
     /// @return rollingSpend Value of spend done by this permission in the past period.
-    function calculateRollingSpend(address account, bytes32 permissionHash, uint256 rollingPeriod)
+    function calculateRollingSpend(address account, bytes32 permissionHash, address token, uint256 rollingPeriod)
         public
         view
         returns (uint256 rollingSpend)
     {
-        uint256 spendsLen = _spends[account][permissionHash].length;
+        uint256 spendsLen = _permissionSpends[account][permissionHash][token].length;
 
         // loop backwards from most recent to oldest spends
         for (uint256 i = spendsLen; i > 0; i--) {
-            Spend memory spend = _spends[account][permissionHash][i - 1];
+            Spend memory spend = _permissionSpends[account][permissionHash][token][i - 1];
 
             // break loop if spend is before our spend period lower bound
             if (spend.timestamp < block.timestamp - rollingPeriod) break;
@@ -178,15 +277,16 @@ contract NativeTokenRollingSpendLimitPermission is IPermissionContract {
         }
     }
 
-    /// @notice Assert native token spend on a rolling period.
+    /// @notice Assert token spend on a rolling period.
     ///
     /// @param permissionHash Hash of the permission.
-    /// @param totalSpend Amount of native token being spent.
+    /// @param token Address of the token being spent, address(0) for native token.
+    /// @param totalSpend Amount of token being spent.
     /// @param rollingPeriod Amount of time in seconds to lookback for rolling spend calculation.
     function _assertSpend(
         bytes32 permissionHash,
+        address token,
         uint256 totalSpend,
-        uint256 spendLimit,
         uint256 rollingPeriod
     ) internal {
         // early return if no value spent
@@ -196,13 +296,14 @@ contract NativeTokenRollingSpendLimitPermission is IPermissionContract {
         if (totalSpend > type(uint208).max) revert SpendValueOverflow();
 
         // check spend value does not exceed limit for period
-        uint256 rollingSpend = calculateRollingSpend(msg.sender, permissionHash, rollingPeriod);
-        if (totalSpend + rollingSpend > spendLimit) revert ExceededSpendingLimit();
+        uint256 rollingSpend = calculateRollingSpend(msg.sender, permissionHash, token, rollingPeriod);
+        uint256 rollingAllowance = _rollingAllowances[msg.sender][permissionHash][token];
+        if (totalSpend + rollingSpend > rollingAllowance) revert ExceededSpendingLimit();
 
         // add spend to state
-        _spends[msg.sender][permissionHash].push(Spend(uint48(block.timestamp), uint208(totalSpend)));
+        _permissionSpends[msg.sender][permissionHash][token].push(Spend(uint48(block.timestamp), uint208(totalSpend)));
 
-        emit SpendRegistered(msg.sender, permissionHash, totalSpend);
+        emit SpendRegistered(msg.sender, permissionHash, token, totalSpend);
     }
 
     /// @notice Check if a call is made on this contract with expected data.


### PR DESCRIPTION
First, I think it's important to align on what an ideal allowance/approval system looks like and the state of the industry.

Goals of an allowance system:
1. Apps ask only for what they need
2. Apps ask only as they need it
3. User experience is smooth

Right now, goal 3 is the dominating factor leading applications to ask for infinite approvals. They ask for hanging allowances because in our previous EOA-first world, external calls could not be batched so an approve+spend interaction requires two signatures, transactions, gas fees, and wait-times. Large (or infinite) hanging allowances help apps ask for permissions once and then support a minimal UX to only transact when spending assets.

Large hanging allowances violate goals 1 & 2 and have become the status quo, unfortunately leading to many industry-wide drainer events when a trusted contract gets exploited. With smart wallets solving the underlying problem of call batching, we have an opportunity to reset the status quo of allowances and create a safer, frictionless experience for users.

This design leans into apps sending calls that batch an `approve` and `permissionedCall` together. When looping over calls within permission validation, we detect an `approve` call and its parameters (token, spender, and allowance value), and add this approval call to our existing `assertSpend` callback at the end of the batch. In that callback, we check that the approval has been used in full (to prevent leaving hanging approvals), the spent value does not exceed the rolling limit, and then store this spend.

Before we enable spending ERC20s, our product will only support spending ETH. To cover the case of spending ERC20s and other tokens through hanging allowances, our cosigner will run a simulation and parse the logs for any outbound `Transfer` event (`from == userOp.sender`), and then revert if any are detected. This is done to ensure we can honor the expectation we set with users that permissions can only spend ETH at launch.

When we roll out ERC20 spending, we just need to update our cosigner logic slightly. Instead of rejecting any outbound `Transfer` event, we will allow it if we witness an exactly matching `Approve` event for the spend. This will guarantee for us that an `approve` call was packed into the calls batch and therefore we can rely on our onchain validation to make sure this spend asserted within the limit and stored.