### PR TITLE
Require paymaster and allow paymaster debiting from user balance

### DIFF
--- a/src/utils/UserOperationLib.sol
+++ b/src/utils/UserOperationLib.sol
@@ -32,6 +32,11 @@ library UserOperationLib {
     /// @param selector Function selector of a call.
     error SelectorNotAllowed(bytes4 selector);
 
+    /// @notice Call value not allowed.
+    ///
+    /// @param value Value of a call.
+    error ValueNotAllowed(uint256 value);
+
     /// @notice Calculate the requiredPrefund amount reserved by Entrypoint to pay for gas.
     ///
     /// @dev Gas not consumed gets refunded to the sponsoring party (user account or paymaster) in postOp process.


### PR DESCRIPTION
There has been an open vulnerability for the cases where a user is paying gas via balance or MagicSpend where the execution could revert (for any reason) which would prevent registering that spend of native token needed to enforce the recurring allowance.

This proposed solution is to set a principle that permissioned userOps should never spend the users assets upfront and only upon successful execution does the user pay. This aligns incentives better with apps, who will bear the upfront cost of a transaction, while still preserving their ability to get debited by the users balance within execution. If an app is submitting transactions that validate but fail at execution, they will own this cost, eliminating this attack vector on user balances.