### PR TITLE
wilson review 1

### DIFF
--- a/src/interfaces/IOffchainAuthorization.sol
+++ b/src/interfaces/IOffchainAuthorization.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.23;
 /// @title IOffchainAuthorization
 ///
 /// @author Coinbase (https://github.com/coinbase/smart-wallet-permissions)
+/// NIT should all of this be in some like permissionCallableExample folder or something? 
+/// This feels very specific to some example contracts and not general? 
 interface IOffchainAuthorization {
     /// @notice Indicate if an offchain request comes from a signer authorized by this contract.
     enum Authorization {

--- a/src/interfaces/IPermissionContract.sol
+++ b/src/interfaces/IPermissionContract.sol
@@ -17,6 +17,7 @@ interface IPermissionContract {
         view;
 
     /// @notice Initialize the permission fields.
+    /// NOTE can you say more here ^ 
     ///
     /// @param account Account of the permission.
     /// @param permissionHash Hash of the permission.

--- a/src/permissions/PermissionCallableAllowedContractNativeTokenRecurringAllowance.sol
+++ b/src/permissions/PermissionCallableAllowedContractNativeTokenRecurringAllowance.sol
@@ -26,6 +26,7 @@ contract PermissionCallableAllowedContractNativeTokenRecurringAllowance is
     NativeTokenRecurringAllowance
 {
     /// @notice Permission-specific values for this permission contract.
+    /// NOTE PermissionValues kinda vague, maybe PermissionDetails a little more clear?  
     struct PermissionValues {
         /// @dev Recurring native token allowance value (struct).
         RecurringAllowance recurringAllowance;
@@ -104,7 +105,7 @@ contract PermissionCallableAllowedContractNativeTokenRecurringAllowance is
                 if (withdraw.asset != address(0)) revert InvalidWithdrawAsset(withdraw.asset);
                 // do not need to accrue callsSpend because withdrawn value will be spent in other calls
             } else if (call.data.length == 0) {
-                // only allow direct ETH transfer for debiting paymaster (optional)
+                // only allow direct ETH transfer for crediting paymaster (optional)
 
                 // check call target is paymaster
                 if (call.target != UserOperationLib.getPaymaster(userOp.paymasterAndData)) {
@@ -130,7 +131,8 @@ contract PermissionCallableAllowedContractNativeTokenRecurringAllowance is
             callsSpend
         );
 
-        // check last call is valid this.useRecurringAllowance
+        /// Should we have a convenience view function that takes an array of calls 
+        /// and adds the state and end calls needed? 
         CoinbaseSmartWallet.Call memory lastCall = calls[callsLen - 1];
         if (lastCall.target != address(this) || !BytesLib.eq(lastCall.data, useRecurringAllowanceData)) {
             revert InvalidUseRecurringAllowanceCall();
@@ -159,7 +161,11 @@ contract PermissionCallableAllowedContractNativeTokenRecurringAllowance is
     ///
     /// @param permissionHash Hash of the permission.
     /// @param callsSpend Value of native token spent on calls.
+    /// Hmm if I'm an app and can trick a user into calling this function, 
+    /// I can mess up the permissions for any session key? 
     function useRecurringAllowance(bytes32 permissionHash, uint256 callsSpend) external {
+        /// Goes for whole code base: named arugments would help for clarity 
+        /// https://github.com/coinbase/solidity-style-guide?tab=readme-ov-file#b-prefer-named-arguments
         _useRecurringAllowance(msg.sender, permissionHash, callsSpend);
     }
 }

--- a/src/utils/NativeTokenRecurringAllowance.sol
+++ b/src/utils/NativeTokenRecurringAllowance.sol
@@ -8,6 +8,8 @@ pragma solidity ^0.8.23;
 /// @dev Allowance and spend values capped at uint160 ~ 1e48.
 ///
 /// @author Coinbase (https://github.com/coinbase/smart-wallet-permissions)
+/// NIT: is this a util? I don't think this and PermissionCallable should be in this folder? 
+/// maybe baseContracts or something ? 
 abstract contract NativeTokenRecurringAllowance {
     /// @notice Recurring allowance parameters.
     struct RecurringAllowance {

--- a/src/utils/P256SignatureCheckerLib.sol
+++ b/src/utils/P256SignatureCheckerLib.sol
@@ -13,6 +13,7 @@ import {WebAuthn} from "webauthn-sol/WebAuthn.sol";
 ///
 /// @author Coinbase (https://github.com/coinbase/smart-wallet)
 /// @author Solady (https://github.com/vectorized/solady/blob/main/src/accounts/ERC4337.sol)
+/// NOTE: I don't think there's much in here from solady, if anything 
 library P256SignatureCheckerLib {
     /// @notice Thrown when a provided signer is neither 64 bytes long (for public key)
     ///         nor a ABI encoded address.

--- a/src/utils/UserOperationLib.sol
+++ b/src/utils/UserOperationLib.sol
@@ -12,6 +12,7 @@ import {UserOperation} from "account-abstraction/interfaces/UserOperation.sol";
 library UserOperationLib {
     address constant ENTRY_POINT_V06 = 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789;
 
+    /// NOTE: Why do we define errors here? it looks like they are only used in one file, and they are not used here? 
     /// @notice UserOperation does not match provided hash.
     ///
     /// @param userOpHash Hash of the user operation.
@@ -41,6 +42,8 @@ library UserOperationLib {
     ///
     /// @dev Gas not consumed gets refunded to the sponsoring party (user account or paymaster) in postOp process.
     /// @dev Implementation forked from
+    /// NIT: user permalink 
+    /// https://github.com/eth-infinitism/account-abstraction/blob/fa61290d37d079e928d92d53a122efcc63822214/contracts/core/EntryPoint.sol#L325
     ///      https://github.com/eth-infinitism/account-abstraction/blob/releases/v0.6/contracts/core/EntryPoint.sol#L325
     ///
     /// @param userOp User operation struct.
@@ -72,6 +75,7 @@ library UserOperationLib {
     ///
     /// @return paymaster Address of contract or address(0) if no paymaster used.
     function getPaymaster(bytes memory paymasterAndData) internal pure returns (address paymaster) {
+        /// note: do you need this conditional? wouldn't it return address(0) either way? 
         return paymasterAndData.length == 0 ? address(0) : address(bytes20(paymasterAndData));
     }
 }


### PR DESCRIPTION
Overall a few style guide issues 
- Incorrect ordering of functions (view and pure should be at bottom) 
- Prefer named arguments for clarity 
- Events emitted before state changes (we actually haven't codified this but should) 

Medium
- Users can be tricked into calling useRecurringAllowance and bork an allowance. 

Low 
- isPermissionApproved doesn't check if revoked, will confuse callers/require calling two  

Info 
_See comments, but a couple to call out_
- P256SignatureCheckerLib name is not accurate 
- Error definitions in `UserOperationLib` not used there and only used in one file: can we put in other file? 
- `rotateCosigner` name confusing
- I would prefer we separate the example code for permissionCallable.
- Some of the things in `/utils` don't feel like utils to me. 
