### PR TITLE
Add additional beforeCalls check that cosigner is non-zero

### DIFF
--- a/src/PermissionManager.sol
+++ b/src/PermissionManager.sol
@@ -197,8 +197,10 @@ contract PermissionManager is IERC1271, Ownable2Step, Pausable {
         // check paymaster enabled
         if (!isPaymasterEnabled[paymaster]) revert DisabledPaymaster(paymaster);
 
-        // check userOpCosigner is cosigner or pendingCosigner
-        if (userOpCosigner != cosigner && userOpCosigner != pendingCosigner) revert InvalidCosigner(userOpCosigner);
+        // check userOpCosigner is non-zero and is cosigner or pendingCosigner
+        if (userOpCosigner == address(0) || (userOpCosigner != cosigner && userOpCosigner != pendingCosigner)) {
+            revert InvalidCosigner(userOpCosigner);
+        }
 
         // approve permission to cache storage for cheaper execution on future use
         approvePermission(permission);

--- a/test/src/PermissionManager/BeforeCalls.t.sol
+++ b/test/src/PermissionManager/BeforeCalls.t.sol
@@ -69,6 +69,19 @@ contract BeforeCallsTest is Test, PermissionManagerBase {
         permissionManager.beforeCalls(permission, address(0), cosigner);
     }
 
+    function test_beforeCalls_revert_zeroCosigner(address paymaster) public {
+        address userOpCosigner = address(0);
+
+        PermissionManager.Permission memory permission = _createPermission();
+
+        vm.startPrank(owner);
+        permissionManager.setPermissionContractEnabled(permission.permissionContract, true);
+        permissionManager.setPaymasterEnabled(paymaster, true);
+
+        vm.expectRevert(abi.encodeWithSelector(PermissionManager.InvalidCosigner.selector, userOpCosigner));
+        permissionManager.beforeCalls(permission, paymaster, userOpCosigner);
+    }
+
     function test_beforeCalls_revert_invalidCosigner(address paymaster, address userOpCosigner) public {
         vm.assume(cosigner != userOpCosigner);
 

--- a/test/src/PermissionManager/BeforeCalls.t.sol
+++ b/test/src/PermissionManager/BeforeCalls.t.sol
@@ -178,6 +178,7 @@ contract BeforeCallsTest is Test, PermissionManagerBase {
 
     function test_beforeCalls_success_pendingCosigner(address paymaster, address newCosigner) public {
         vm.assume(paymaster != address(0));
+        vm.assume(newCosigner != address(0));
 
         PermissionManager.Permission memory permission = _createPermission();
 


### PR DESCRIPTION
For most of the time, `pendingCosigner` will actually be the zero address. A failed `ecrecover` returns `address(0)` which would pass validation in `beforeCalls`, which would effectively mean any cosignature could be forged and the validation is not passing. This would be a severe bug if true. From my initial skims on Solady, it does not seem like it does any post-processing of `ecrecover` so a return value of `address(0)` would indeed be possible.