### PR TITLE
Add Brickable security utility

### DIFF
--- a/src/mixins/Brickable.sol
+++ b/src/mixins/Brickable.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {SignatureCheckerLib} from "solady/utils/SignatureCheckerLib.sol";
+
+/// @title Brickable
+///
+/// @notice A last-resort utility to irreversibly brick a contract against an adversarial environment.
+///
+/// @dev Signature authorization designed to enable brick transactions even if brick authorizer key compromised.
+/// @dev Brick message is chain-invariant to enable cross-chain replay even if brick authorizer key becomes unavailable.
+///
+/// @author Coinbase
+contract Brickable {
+    /// @notice Immutable entity for authorizing the brick.
+    address public immutable brickAuthorizer;
+
+    /// @notice Store if the contract has been bricked or not.
+    bool private _bricked;
+
+    /// @notice Immutable hash of the utilizing contract's name.
+    bytes32 private immutable nameHash;
+
+    /// @notice Immutable salt for the hash computation to enable cross-chain replay.
+    bytes32 private immutable chainInvariantSalt;
+
+    /// @notice
+    error InvalidBrickAuthorizer();
+
+    /// @notice Bricked status is enforced.
+    error EnforcedBrick();
+
+    /// @notice Brick request is unauthorized.
+    error UnauthorizedBrick();
+
+    /// @notice Contract has been irreversibly bricked.
+    event Bricked();
+
+    /// @notice Constructor.
+    ///
+    /// @param authorizer Address of the authorizing entity that can trigger bricks.
+    /// @param name String name of the utilizing contract.
+    /// @param salt Chain-invariant salt to replace typical chainId+verifyingContract replay protection.
+    constructor(address authorizer, string memory name, bytes32 salt) {
+        if (authorizer == address(0)) revert InvalidBrickAuthorizer();
+        brickAuthorizer = authorizer;
+        nameHash = keccak256(bytes(name));
+        chainInvariantSalt = salt;
+    }
+
+    /// @notice Require modified function to not be bricked.
+    modifier whenNotBricked() {
+        _requireNotBricked();
+        _;
+    }
+
+    /// @notice Brick this contract via authorizer signature.
+    ///
+    /// @dev Signature authorization was chosen because we assume an adversarial environment where authorizer key
+    ///      may also be compromised and struggle to submit transactions due to automated draining transactions.
+    ///
+    /// @param signature Bytes signed over the constant brick message.
+    function brick(bytes calldata signature) external {
+        // early return if already bricked
+        if (bricked()) return;
+
+        // check if brick signature is authorized
+        if (!SignatureCheckerLib.isValidSignatureNow(brickAuthorizer, _eip712Hash(), signature)) {
+            revert UnauthorizedBrick();
+        }
+
+        _bricked = true;
+        emit Bricked();
+    }
+
+    /// @notice Read if this contract is bricked.
+    ///
+    /// @return bricked True if this contract is bricked.
+    function bricked() public view returns (bool) {
+        return _bricked;
+    }
+
+    /// @notice Revert if this contract is bricked.
+    function _requireNotBricked() internal view {
+        if (bricked()) revert EnforcedBrick();
+    }
+
+    /// @notice Compute the constant hash for brick authorization signatures.
+    ///
+    /// @return hash EIP-712 hash of the brick message.
+    function _eip712Hash() private view returns (bytes32) {
+        bytes32 domainSeparator =
+            keccak256(abi.encode(keccak256("EIP712Domain(string name,bytes32 salt)"), nameHash, chainInvariantSalt));
+        bytes32 hashStruct = keccak256(abi.encode(keccak256("Brick()")));
+
+        return keccak256(abi.encodePacked("\x19\x01", domainSeparator, hashStruct));
+    }
+}


### PR DESCRIPTION
In both of the two most severe security incidents – compromised Permission Manager or compromised owner key – there is a common desire to shut down the entire system irreversibly. `Brickable` is an attempt to create a new mechanism on top of `Pausable` to irreversibly brick the Permission Manager from functioning. Designing for the compromised owner scenario is more difficult as it uproots a lot of assumptions we normally make about our key custody systems. 

The majority of the design intention assumes that we are now in an adversarial environment where we need to assume we have already leaked the owner and it has already been rotated.

In this scenario, we desire a different, immutable key that has the ability to brick Permission Manager independent of the owner. If we assume the owner has been compromised (leaked key), we must also assume that the brick authorizer is also leaked. Therefore, we can not count on our ability to submit transactions from this address because an automated drainer could easily take ETH out as we try to fund a transaction to brick the Permission Manager. To get around this, we design our `brick` function to rely on signature authorization which relies on a softer guarantee that at least we still have access to our key even if someone else does now too.

I would also like to extend our protection to include if we lose availability of the brick authorizer amidst this chaos. The brick message supports chain-invariant hashing (including relying on consistent Permission Manager addresses) so that we can guarantee we can brick on all chains all even if we lose access to the brick key halfway. In cases where a specific chain has a specific nuance that created the vulnerability, we can also brick the contract on only one chain without this replay ability. 

Should this mechanism be deemed worthwhile, I will add tests and incorporate it into the Permission Manager.