### PR TITLE
Enforce paymaster in Permission Manager

### DIFF
--- a/src/PermissionManager.sol
+++ b/src/PermissionManager.sol
@@ -88,6 +88,9 @@ contract PermissionManager is IERC1271, Ownable2Step, Pausable {
     /// @param sender Account that the user operation is made from.
     error InvalidUserOperationSender(address sender);
 
+    /// @notice UserOperation does not use a paymaster
+    error InvalidUserOperationPaymaster();
+
     /// @notice Permission is unauthorized by either revocation or lack of approval.
     error UnauthorizedPermission();
 
@@ -330,6 +333,9 @@ contract PermissionManager is IERC1271, Ownable2Step, Pausable {
         if (UserOperationLib.getUserOpHash(data.userOp) != userOpHash) {
             revert InvalidUserOperationHash(UserOperationLib.getUserOpHash(data.userOp));
         }
+
+        // check userOp uses a paymaster
+        if (bytes20(data.userOp.paymasterAndData) == bytes20(0)) revert InvalidUserOperationPaymaster();
 
         // check permission authorized (approved and not yet revoked)
         if (!isPermissionAuthorized(data.permission)) revert UnauthorizedPermission();

--- a/test/base/Base.sol
+++ b/test/base/Base.sol
@@ -13,6 +13,7 @@ import {MockContractSigner} from "../mocks/MockContractSigner.sol";
 contract Base is Test {
     string public constant BASE_SEPOLIA_RPC = "https://sepolia.base.org";
     address constant ENTRY_POINT_V06 = 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789;
+    address constant CDP_PAYMASTER = 0xC484bCD10aB8AD132843872DEb1a0AdC1473189c;
     bytes4 constant EIP1271_MAGIC_VALUE = 0x1626ba7e;
     uint256 ownerPk = uint256(keccak256("owner"));
     address owner = vm.addr(ownerPk);
@@ -44,7 +45,7 @@ contract Base is Test {
             preVerificationGas: 0,
             maxFeePerGas: 0,
             maxPriorityFeePerGas: 0,
-            paymasterAndData: hex"",
+            paymasterAndData: abi.encodePacked(CDP_PAYMASTER),
             signature: hex""
         });
     }

--- a/test/src/PermissionManager/IsValidSignature.t.sol
+++ b/test/src/PermissionManager/IsValidSignature.t.sol
@@ -56,6 +56,22 @@ contract IsValidSignatureTest is Test, PermissionManagerBase {
         permissionManager.isValidSignature(hash, abi.encode(pUserOp));
     }
 
+    function test_isValidSignature_revert_InvalidUserOperationPaymaster() public {
+        UserOperation memory userOp = _createUserOperation();
+        userOp.paymasterAndData = hex"";
+
+        PermissionManager.Permission memory permission = _createPermission();
+        PermissionManager.PermissionedUserOperation memory pUserOp = PermissionManager.PermissionedUserOperation({
+            permission: permission,
+            userOp: userOp,
+            userOpSignature: hex"",
+            userOpCosignature: hex""
+        });
+
+        vm.expectRevert(PermissionManager.InvalidUserOperationPaymaster.selector);
+        permissionManager.isValidSignature(UserOperationLib.getUserOpHash(userOp), abi.encode(pUserOp));
+    }
+
     function test_isValidSignature_revert_revokedPermission() public {
         PermissionManager.Permission memory permission = _createPermission();
         bytes32 permissionHash = permissionManager.hashPermission(permission);


### PR DESCRIPTION
Although not explicitly requested as a finding, it is in the same vein of the main ERC20 paymaster finding to also consider ways for native token to be drained in a similar fashion. The main case I see is if a user approves a permission with a permission contract that does not enforce a paymaster, then the signer on that permission can drain the user's native token balance on failed user operations which also cannot be prevented by the cosigner. The `isPermissionContractEnabled` storage also does protect users because it is checked in execution phase, just like the `isPaymasterEnabled` check.

Previously, we were not confident that we wanted to make this decision at the Manager level for reversibility, but now we have the confidence to outright prevent this risk by explicitly rejecting no-paymaster user operations in validation phase, independent of cosigning.