### PR TITLE
Add batch signing via hash merklization

### DIFF
--- a/docs/BatchSigning.md
+++ b/docs/BatchSigning.md
@@ -56,7 +56,7 @@ If an app only needs to request a single recurring allowance, the leaf node is a
 
 ### Multiple Allownaces
 
-Below is pseudo-code for offchain preparation of the Merkle Tree, root, signature, and individual contexts returned back to the app.
+Below is pseudo-code for offchain preparation of the Merkle Tree, root, signature, and individual contexts returned back to the app. Note that `makeMerkleTree`, `getProof`, and `getRoot` are utilities specific to batch signing and are found in [`merkleTree.ts`](../node/utils/merkleTree.ts).
 
 ```tsx
 // receive spend permissions RPC request

--- a/docs/BatchSigning.md
+++ b/docs/BatchSigning.md
@@ -1,0 +1,53 @@
+# Batch Signing
+
+Apps may request to spend many different tokens from a user. If users have to sign each spend permission individually, this could be a minor nuissance at minimum, or make certain applications wholly impractical at maximum. Our goal with a Batch Signing feature is to enable users to only have to sign once for an arbitrary number of spend permissions.
+
+## Data Structure
+
+There are a three general approaches to allow us to do this:
+
+1. Array-ify a subset of fields within `RecurringAllowance` (e.g. `token` and `allowance`) and keep the other fields shared for the batch
+1. Allow an array of `RecurringAllowance` structs and sign over the hash of the array.
+1. Allow an array of `RecurringAllowance` structs and sign over a Merkle root where the structs are leaves in a Merkle Tree.
+
+The first option is most similar to [Permit2](https://github.com/Uniswap/permit2/blob/main/src/interfaces/ISignatureTransfer.sol#L51-L58) and is straightforward. The main downside is that this locks us into grouping by fields not included in the array which we currently lack sufficient product confidence to make a decision of what should be forced to be consistent across all allowances.
+
+The second option allows us to be flexible with batching with variation across any fields. The main downside is that we may be sending a lot of calldata depending on how many allowances are batched together. Additionally, if we do end up sharing the same values for many fields, we are wasting calldata on this duplication.
+
+The third option allows us to maintain flexibility with better gas scaling. The array of recurring allowances are hashed, sorted, and then iteratively hashed up forming a Merkle Tree. The root of this tree is what users actually sign with their Smart Wallet and can be used to approve any recurring allowance within in. To submit a `permit` to validate the signature and apply the approval, we just need to provide the `RecurringAllowance` struct and a `bytes32[]` path of intermediate hashes to reconstruct the root. Note that the number of elements in this array scaled `0(log(n))` which is more favorable than the previous option and also each element only takes up one word of calldata.
+
+![merkleTree](https://github.com/user-attachments/assets/9b2cf44d-8a67-430b-a5a9-4ed78dd7a973)
+
+There are three kinds of nodes in our Merkle Tree computed as:
+
+1. Leaf nodes: Hashes of individual `RecurringAllowance` structs
+1. Intermediate nodes: Hashes of concatenating two sibling nodes (children of the same parent)
+1. Root node: Final intermediate node where there are no more siblings to hash with
+
+## Offchain Hash Construction
+
+Given an array of recurring allowances, we need to compute a Merkle root for the user to sign.
+
+We start by hashing our `RecurringAllowance` structs to form our leaf nodes with: `keccak256(abi.encode(recurringAllowance, chainId, verifyingContract))`. With an array of leaf nodes of shape `bytes32[]`, we sort this array in increasing order. Iteratively, we hash pairs of sibling nodes via `keccak256(abi.encode(lowerSibling, higherSibling))` to build up more layers of the tree with each layer being half the width of the previous layer. Note that between a pair of sibling nodes, the order within the hash computation **does matter**. We consistently order our hashing by comparing the values of the two siblings and make sure the ordering is lower then higher sibling. We continue iteratively hashing until we reach one final root node.
+
+Our [offchain implementation](../node/utils/merkleTree.ts) is a fork of [openzeppelin/merkle-tree](https://github.com/OpenZeppelin/merkle-tree) rewritten with `viem` and focused on their "simple" Merkle Tree implementation without [Second Preimage Attack](https://flawed.net.nz/2018/02/21/attacking-merkle-trees-with-a-second-preimage-attack/) mitigation.
+
+## Onchain Signature Verification
+
+After the user signs the batch of recurring allowances, we determine the individual Merkle proofs (type `bytes32[]`) for each and add it to a `SignedPermission` struct that contains the recurring allowance and user signature. Apps receive an array of permission contexts, one per recurring allowance, that is computed as a simple ABI-encoding of `SignedPermission`.
+
+When submitting a request to `withdraw`, apps can provide this context as-is and we will attempt to verify the permit and then withdraw against the allowance. Verifying a permit starts with recomputing the Merkle root by converting the `RecurringAllowance` to a leaf node via `keccak256(abi.encode(recurringAllowance, chainId, verifyingContract))` and then iterating over the `bytes32[] proof` array by iteratively chaining hashes. We use [OpenZeppelin's `MerkleProof` library](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/MerkleProof.sol#L57-L63) to implement this iteration and root generation.
+
+Note that the iterative hashing of a proof also applies the same commutative hashing process where the lower sibling is always first in the concatenation for parity with offchain. We use [OpenZeppelin's `Hashes` library](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/Hashes.sol) to implement this commutative hashing.
+
+After computing a Merkle root, we then check the provided `SignedPermission.signature` is valid by calling the recurring allowance's account with EIP-1271 `isValidSignature`. If the leaf node or Merkle proof are invalid, the computed root hash would change and not validate for the provided signature.
+
+## Future Composability
+
+Note that the inclusion of `chainId` and `verifyingContract` in the leaf hash for a recurring allowance is intentional in that it keeps the root hash agnostic to chain and contract choice. This allows us to perform cross-chain and cross-contract batch signatures while still preserving cross-chain and cross-contract replay protection.
+
+We also have open-ended flexibility to compose other kinds of leaf nodes, for example a future `NftAllowance` struct, within the same batch signing event as Spend Permissions V1. This composability is powerful for future product developments, but deserves security scrutiny for potentially being too flexible.
+
+## Simple Base Case Usage
+
+If an app only needs to request a single recurring allowance, the leaf node is also the root node. This means the `bytes32[]` Merkle proof will be an empty array and no iterative hashing is performed. This effectively means that non-batched signatures function exactly the same as if this batching mechanism didn't exist. This provides us an easy way to implement our V1 on the offchain side without concerning ourselves with this more advanced Merkle Tree construction.

--- a/node/utils/merkleTree.ts
+++ b/node/utils/merkleTree.ts
@@ -19,7 +19,15 @@ export function makeMerkleTree(leaves: Hex[]): Hex[] {
   return tree;
 }
 
-export function getProof(tree: Hex[], index: number): Hex[] {
+export function getRoot(tree: Hex[]): Hex {
+  if (tree.length === 0) throwError('Tree has no root');
+  return tree[0];
+}
+
+export function getProof(tree: Hex[], leaf: Hex): Hex[] {
+  let index = tree.indexOf(leaf)
+  if (index === -1) throwError("Leaf does not exist in tree")
+
   checkLeafNode(tree, index);
 
   const proof: Hex[] = [];

--- a/node/utils/merkleTree.ts
+++ b/node/utils/merkleTree.ts
@@ -1,0 +1,132 @@
+// forked from Open Zeppelin: https://github.com/OpenZeppelin/merkle-tree/blob/master/src/core.ts
+
+import {concat, Hex, isHex, keccak256, size} from "viem"
+
+const leftChildIndex = (i: number) => 2 * i + 1;
+const rightChildIndex = (i: number) => 2 * i + 2;
+const parentIndex = (i: number) => (i > 0 ? Math.floor((i - 1) / 2) : throwError('Root has no parent'));
+const siblingIndex = (i: number) => (i > 0 ? i - (-1) ** (i % 2) : throwError('Root has no siblings'));
+
+const isTreeNode = (tree: unknown[], i: number) => i >= 0 && i < tree.length;
+const isInternalNode = (tree: unknown[], i: number) => isTreeNode(tree, leftChildIndex(i));
+const isLeafNode = (tree: unknown[], i: number) => isTreeNode(tree, i) && !isInternalNode(tree, i);
+const isValidMerkleNode = (node: Hex) => isHex(node) && size(node) === 32;
+
+const checkLeafNode = (tree: unknown[], i: number) => void (isLeafNode(tree, i) || throwError('Index is not a leaf'));
+const checkValidMerkleNode = (node: Hex) =>
+  void (isValidMerkleNode(node) || throwError('Merkle tree nodes must be Uint8Array of length 32'));
+
+export function makeMerkleTree(leaves: Hex[]): Hex[] {
+  leaves.forEach(checkValidMerkleNode);
+
+  validateArgument(leaves.length !== 0, 'Expected non-zero number of leaves');
+
+  const tree = new Array<Hex>(2 * leaves.length - 1);
+
+  for (const [i, leaf] of leaves.entries()) {
+    tree[tree.length - 1 - i] = leaf;
+  }
+  for (let i = tree.length - 1 - leaves.length; i >= 0; i--) {
+    tree[i] = commutativeKeccak256(tree[leftChildIndex(i)]!, tree[rightChildIndex(i)]!);
+  }
+
+  return tree;
+}
+
+export function getProof(tree: Hex[], index: number): Hex[] {
+  checkLeafNode(tree, index);
+
+  const proof: Hex[] = [];
+  while (index > 0) {
+    proof.push(tree[siblingIndex(index)]!);
+    index = parentIndex(index);
+  }
+  return proof;
+}
+
+export function processProof(leaf: Hex, proof: Hex[]): Hex {
+  checkValidMerkleNode(leaf);
+  proof.forEach(checkValidMerkleNode);
+
+  return proof.reduce(commutativeKeccak256, leaf);
+}
+
+export function isValidMerkleTree(tree: Hex[]): boolean {
+  for (const [i, node] of tree.entries()) {
+    if (!isValidMerkleNode(node)) {
+      return false;
+    }
+
+    const l = leftChildIndex(i);
+    const r = rightChildIndex(i);
+
+    if (r >= tree.length) {
+      if (l < tree.length) {
+        return false;
+      }
+    } else if (compare(node, commutativeKeccak256(tree[l]!, tree[r]!))) {
+      return false;
+    }
+  }
+
+  return tree.length > 0;
+}
+
+// debug tool to visualize tree
+export function renderMerkleTree(tree: Hex[]): string {
+  validateArgument(tree.length !== 0, 'Expected non-zero number of nodes');
+
+  const stack: [number, number[]][] = [[0, []]];
+
+  const lines: string[] = [];
+
+  while (stack.length > 0) {
+    const [i, path] = stack.pop()!;
+
+    lines.push(
+      path
+        .slice(0, -1)
+        .map(p => ['   ', '│  '][p])
+        .join('') +
+        path
+          .slice(-1)
+          .map(p => ['└─ ', '├─ '][p])
+          .join('') +
+        i +
+        ') ' +
+        tree[i]!,
+    );
+
+    if (rightChildIndex(i) < tree.length) {
+      stack.push([rightChildIndex(i), path.concat(0)]);
+      stack.push([leftChildIndex(i), path.concat(1)]);
+    }
+  }
+
+  return lines.join('\n');
+}
+function compare(a: Hex, b: Hex): number {
+    const diff = BigInt(a) - BigInt(b);
+    return diff > 0 ? 1 : diff < 0 ? -1 : 0;
+}
+
+function commutativeKeccak256(a: Hex, b: Hex): Hex {
+    return keccak256(concat([a, b].sort(compare)))
+}
+
+function throwError(message?: string): never {
+    throw new Error(message);
+}
+  
+class InvalidArgumentError extends Error {
+    constructor(message?: string) {
+      super(message);
+      this.name = 'InvalidArgumentError';
+    }
+}
+  
+function validateArgument(condition: unknown, message?: string): asserts condition {
+    if (!condition) {
+      throw new InvalidArgumentError(message);
+    }
+}

--- a/node/utils/merkleTree.ts
+++ b/node/utils/merkleTree.ts
@@ -1,25 +1,11 @@
-// forked from Open Zeppelin: https://github.com/OpenZeppelin/merkle-tree/blob/master/src/core.ts
-
 import {concat, Hex, isHex, keccak256, size} from "viem"
 
-const leftChildIndex = (i: number) => 2 * i + 1;
-const rightChildIndex = (i: number) => 2 * i + 2;
-const parentIndex = (i: number) => (i > 0 ? Math.floor((i - 1) / 2) : throwError('Root has no parent'));
-const siblingIndex = (i: number) => (i > 0 ? i - (-1) ** (i % 2) : throwError('Root has no siblings'));
-
-const isTreeNode = (tree: unknown[], i: number) => i >= 0 && i < tree.length;
-const isInternalNode = (tree: unknown[], i: number) => isTreeNode(tree, leftChildIndex(i));
-const isLeafNode = (tree: unknown[], i: number) => isTreeNode(tree, i) && !isInternalNode(tree, i);
-const isValidMerkleNode = (node: Hex) => isHex(node) && size(node) === 32;
-
-const checkLeafNode = (tree: unknown[], i: number) => void (isLeafNode(tree, i) || throwError('Index is not a leaf'));
-const checkValidMerkleNode = (node: Hex) =>
-  void (isValidMerkleNode(node) || throwError('Merkle tree nodes must be Uint8Array of length 32'));
+// Implementation forked from Open Zeppelin: https://github.com/OpenZeppelin/merkle-tree/blob/master/src/core.ts
 
 export function makeMerkleTree(leaves: Hex[]): Hex[] {
   leaves.forEach(checkValidMerkleNode);
 
-  validateArgument(leaves.length !== 0, 'Expected non-zero number of leaves');
+  if (leaves.length === 0) throwError('Expected non-zero number of leaves');
 
   const tree = new Array<Hex>(2 * leaves.length - 1);
 
@@ -44,89 +30,30 @@ export function getProof(tree: Hex[], index: number): Hex[] {
   return proof;
 }
 
-export function processProof(leaf: Hex, proof: Hex[]): Hex {
-  checkValidMerkleNode(leaf);
-  proof.forEach(checkValidMerkleNode);
-
-  return proof.reduce(commutativeKeccak256, leaf);
+function commutativeKeccak256(a: Hex, b: Hex): Hex {
+  return keccak256(concat([a, b].sort(compare)))
 }
 
-export function isValidMerkleTree(tree: Hex[]): boolean {
-  for (const [i, node] of tree.entries()) {
-    if (!isValidMerkleNode(node)) {
-      return false;
-    }
-
-    const l = leftChildIndex(i);
-    const r = rightChildIndex(i);
-
-    if (r >= tree.length) {
-      if (l < tree.length) {
-        return false;
-      }
-    } else if (compare(node, commutativeKeccak256(tree[l]!, tree[r]!))) {
-      return false;
-    }
-  }
-
-  return tree.length > 0;
-}
-
-// debug tool to visualize tree
-export function renderMerkleTree(tree: Hex[]): string {
-  validateArgument(tree.length !== 0, 'Expected non-zero number of nodes');
-
-  const stack: [number, number[]][] = [[0, []]];
-
-  const lines: string[] = [];
-
-  while (stack.length > 0) {
-    const [i, path] = stack.pop()!;
-
-    lines.push(
-      path
-        .slice(0, -1)
-        .map(p => ['   ', '│  '][p])
-        .join('') +
-        path
-          .slice(-1)
-          .map(p => ['└─ ', '├─ '][p])
-          .join('') +
-        i +
-        ') ' +
-        tree[i]!,
-    );
-
-    if (rightChildIndex(i) < tree.length) {
-      stack.push([rightChildIndex(i), path.concat(0)]);
-      stack.push([leftChildIndex(i), path.concat(1)]);
-    }
-  }
-
-  return lines.join('\n');
-}
 function compare(a: Hex, b: Hex): number {
     const diff = BigInt(a) - BigInt(b);
     return diff > 0 ? 1 : diff < 0 ? -1 : 0;
 }
 
-function commutativeKeccak256(a: Hex, b: Hex): Hex {
-    return keccak256(concat([a, b].sort(compare)))
-}
+const leftChildIndex = (i: number) => 2 * i + 1;
+const rightChildIndex = (i: number) => 2 * i + 2;
+const parentIndex = (i: number) => (i > 0 ? Math.floor((i - 1) / 2) : throwError('Root has no parent'));
+const siblingIndex = (i: number) => (i > 0 ? i - (-1) ** (i % 2) : throwError('Root has no siblings'));
+
+const isTreeNode = (tree: unknown[], i: number) => i >= 0 && i < tree.length;
+const isInternalNode = (tree: unknown[], i: number) => isTreeNode(tree, leftChildIndex(i));
+const isLeafNode = (tree: unknown[], i: number) => isTreeNode(tree, i) && !isInternalNode(tree, i);
+const isValidMerkleNode = (node: Hex) => isHex(node) && size(node) === 32;
+
+const checkLeafNode = (tree: unknown[], i: number) => void (isLeafNode(tree, i) || throwError('Index is not a leaf'));
+const checkValidMerkleNode = (node: Hex) =>
+  void (isValidMerkleNode(node) || throwError('Merkle tree nodes must be Uint8Array of length 32'));
+
 
 function throwError(message?: string): never {
-    throw new Error(message);
-}
-  
-class InvalidArgumentError extends Error {
-    constructor(message?: string) {
-      super(message);
-      this.name = 'InvalidArgumentError';
-    }
-}
-  
-function validateArgument(condition: unknown, message?: string): asserts condition {
-    if (!condition) {
-      throw new InvalidArgumentError(message);
-    }
+  throw new Error(message);
 }

--- a/src/SpendPermissions.sol
+++ b/src/SpendPermissions.sol
@@ -207,9 +207,10 @@ contract SpendPermissions {
         return keccak256(abi.encode(recurringAllowance, block.chainid, address(this)));
     }
 
-    /// @notice Hash a RecurringAllowance struct for signing.
+    /// @notice Hash a SignedPermission struct for signing.
     ///
     /// @dev Prevent phishing permits by making the hash incompatible with EIP-191/712.
+    /// @dev If signing only one recurring allowance, then the recurring allowance hash is the merkle root to sign.
     ///
     /// @param signedPermission Signed recurring allowance permission.
     ///

--- a/src/SpendPermissions.sol
+++ b/src/SpendPermissions.sol
@@ -173,7 +173,7 @@ contract SpendPermissions {
         // validate signature over recurring allowance data
         if (
             IERC1271(signedPermission.recurringAllowance.account).isValidSignature(
-                getRoot(signedPermission), signedPermission.signature
+                getHash(signedPermission), signedPermission.signature
             ) != IERC1271.isValidSignature.selector
         ) {
             revert UnauthorizedRecurringAllowance();


### PR DESCRIPTION
Support batch signing with simple merklization of the hash. Still supports single signatures easily by just using empty arrays as the `btes32[] proof` field. Gives us forwards compatibility to add batch signing on the web-side as needed. Note that the frontend is trusted to prepare hashes honestly for users to sign for existing features like userOp preparation and even existing spend permissions too, so the trust model seems untouched.

Note that recurring allowances still have individualized state for approvals and revocations and permit flows still need to be done per-permission. This just adds batch signing as a new capability offchain.

Something feels a bit too flexible about this merklization, so I would be open to adding some kind of specific hash prefix just for `"SpendPermissions"` on the final root calculation. Need to consider security risks of this approach and generally it just places more risk on the frontend to prepare hashes correctly.