### PR TITLE
suggestive refactor

### DIFF
--- a/test/src/SpendPermissions/Debug.t.sol
+++ b/test/src/SpendPermissions/Debug.t.sol
@@ -3,52 +3,52 @@ pragma solidity ^0.8.23;
 
 import {Test, console2} from "forge-std/Test.sol";
 
-import {SpendPermissions} from "../../../../src/SpendPermissions.sol";
+import {SpendPermissionManager} from "../../../../src/SpendPermissionManager.sol";
 
 import {Base} from "../../base/Base.sol";
 
 contract DebugTest is Test, Base {
     address public constant ETHER = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
-    SpendPermissions spendPermissions;
+    SpendPermissionManager manager;
 
     function setUp() public {
         _initialize();
 
-        spendPermissions = new SpendPermissions();
+        manager = new SpendPermissionManager();
 
         vm.prank(owner);
-        account.addOwnerAddress(address(spendPermissions));
+        account.addOwnerAddress(address(manager));
     }
 
     function test_approve() public {
-        SpendPermissions.RecurringAllowance memory recurringAllowance = _createRecurringAllowance();
+        SpendPermissionManager.SpendPermission memory spendPermission = _createSpendPermission();
 
         vm.prank(address(account));
-        spendPermissions.approve(recurringAllowance);
+        manager.approveSpendPermission(spendPermission);
     }
 
-    function test_withdraw(address recipient) public {
-        vm.assume(recipient != address(spendPermissions));
-        SpendPermissions.RecurringAllowance memory recurringAllowance = _createRecurringAllowance();
+    function test_spend(address recipient) public {
+        vm.assume(recipient != address(manager));
+        SpendPermissionManager.SpendPermission memory spendPermission = _createSpendPermission();
 
         vm.prank(address(account));
-        spendPermissions.approve(recurringAllowance);
+        manager.approveSpendPermission(spendPermission);
 
         vm.deal(address(account), 1 ether);
         vm.prank(owner);
-        spendPermissions.withdraw(recurringAllowance, recipient, 1 ether / 2);
+        manager.spend(spendPermission, recipient, 1 ether / 2);
     }
 
-    function _createRecurringAllowance() internal view returns (SpendPermissions.RecurringAllowance memory) {
-        return SpendPermissions.RecurringAllowance({
+    function _createSpendPermission() internal view returns (SpendPermissionManager.SpendPermission memory) {
+        return SpendPermissionManager.SpendPermission({
             account: address(account),
             spender: owner,
             token: ETHER,
             start: 0,
             end: 1758791693, // 1 year from now
             period: 86400, // 1 day
-            allowance: 1 ether
+            amountPerPeriod: 1 ether
         });
     }
 }


### PR DESCRIPTION
In this PR I
- Refactored for more explicit names, e.g.
  - approve -> approveSpendPermission
  - permit -> approveSpendPermissionWithSignature
- Tried to simplify diverging terms for the same thing 
  - Authorized vs. approved
  - cycle vs. period 
  - Spend Permission vs. recurring allowance 

I also switched to use EIP-712 for the signatures, so that this spend permissions could be signed via eth_signTypedData and possibly be more generally compatible with the existing wallet ecosystem. 